### PR TITLE
Adds wemake-vue-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 ### Examples
 
 - [Project using Jest + vue-test-utils together](https://github.com/vuejs/vue-test-utils-jest-example)
+- [Project template using Jest, vue-test-utils, and TestCafe](https://github.com/wemake-services/wemake-vue-template)
 
 
 ## CONTRIBUTING


### PR DESCRIPTION
I would also like to provide a separate link to our documentation. It is pretty useful, at least I hope so.

Here are the interesting parts:
- https://wemake-services.gitbook.io/wemake-vue-template/testing
- https://wemake-services.gitbook.io/wemake-vue-template/qa

Is it possible?